### PR TITLE
Feature: DTM-29-limit-get-event-letter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 dependencies {
     runtimeOnly 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.4'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.4'
@@ -47,6 +48,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.26'
     annotationProcessor 'org.projectlombok:lombok:1.18.26'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.0'
+    testRuntimeOnly 'com.h2database:h2'
     implementation 'org.springframework:spring-test:6.0.6'
 
     //swagger

--- a/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
+++ b/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
@@ -1,6 +1,7 @@
 package gifterz.textme.domain.letter.controller;
 
 import gifterz.textme.domain.letter.dto.request.EventLetterRequest;
+import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.service.EventLetterService;
 import gifterz.textme.global.auth.role.UserAuth;
 import gifterz.textme.global.security.jwt.JwtAuthentication;
@@ -21,6 +22,13 @@ public class EventLetterController {
     public ResponseEntity<Void> sendLetter(JwtAuthentication auth, @RequestBody @Valid EventLetterRequest request) {
         eventLetterService.sendLetter(auth.getUserId(), request.toSenderInfo(), request.toTarget());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/{id}")
+    @UserAuth
+    public ResponseEntity<EventLetterResponse> findLetter(JwtAuthentication auth, @PathVariable("id") final Long letterId) {
+        EventLetterResponse response = eventLetterService.findLetter(auth.getUserId(), letterId);
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/gifterz/textme/domain/letter/dto/response/EventLetterResponse.java
+++ b/src/main/java/gifterz/textme/domain/letter/dto/response/EventLetterResponse.java
@@ -1,0 +1,22 @@
+package gifterz.textme.domain.letter.dto.response;
+
+
+import gifterz.textme.domain.letter.entity.EventLetter;
+
+public record EventLetterResponse(
+        Long id,
+        String senderName,
+        String contents,
+        String imageUrl,
+        String contactInfo
+
+) {
+    public static EventLetterResponse of(EventLetter eventLetter) {
+        return new EventLetterResponse(
+                eventLetter.getId(),
+                eventLetter.getSenderName(),
+                eventLetter.getContents(),
+                eventLetter.getImageUrl(),
+                eventLetter.getContactInfo());
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -1,6 +1,7 @@
 package gifterz.textme.domain.letter.entity;
 
 import gifterz.textme.domain.entity.BaseEntity;
+import gifterz.textme.domain.entity.StatusType;
 import gifterz.textme.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -41,6 +42,7 @@ public class EventLetter extends BaseEntity {
 
     private EventLetter(User user, String senderName, String contents,
                         String imageUrl, String contactInfo, Integer viewCount) {
+        super(StatusType.ACTIVATE.getStatus());
         this.user = user;
         this.senderName = senderName;
         this.contents = contents;

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -55,6 +55,13 @@ public class EventLetter extends BaseEntity {
 
     public void increaseViewCount() {
         this.viewCount++;
+        if (this.viewCount >= 3) {
+            this.deactivate();
+        }
+    }
+
+    public void deactivate() {
+        this.status = StatusType.DEACTIVATE.getStatus();
     }
 
     @Override

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -39,6 +39,9 @@ public class EventLetter extends BaseEntity {
 
     @Version
     private Long version;
+
+    public final static int MAX_VIEW_COUNT = 3;
+
     public static EventLetter of(User user, String senderName, String contents,
                                  String imageUrl, String contactInfo) {
         return new EventLetter(user, senderName, contents, imageUrl, contactInfo, 0);

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -50,4 +50,24 @@ public class EventLetter extends BaseEntity {
         this.contactInfo = contactInfo;
         this.viewCount = viewCount;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EventLetter that = (EventLetter) o;
+
+        return Objects.equals(id, that.id) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(senderName, that.senderName) &&
+                Objects.equals(contents, that.contents) &&
+                Objects.equals(imageUrl, that.imageUrl) &&
+                Objects.equals(contactInfo, that.contactInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, user, senderName, contents, imageUrl, contactInfo);
+    }
 }

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -37,6 +37,8 @@ public class EventLetter extends BaseEntity {
 
     private Integer viewCount;
 
+    @Version
+    private Long version;
     public static EventLetter of(User user, String senderName, String contents,
                                  String imageUrl, String contactInfo) {
         return new EventLetter(user, senderName, contents, imageUrl, contactInfo, 0);
@@ -55,7 +57,7 @@ public class EventLetter extends BaseEntity {
 
     public void increaseViewCount() {
         this.viewCount++;
-        if (this.viewCount >= 3) {
+        if (this.viewCount >= MAX_VIEW_COUNT) {
             this.deactivate();
         }
     }

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,6 +51,10 @@ public class EventLetter extends BaseEntity {
         this.imageUrl = imageUrl;
         this.contactInfo = contactInfo;
         this.viewCount = viewCount;
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
     }
 
     @Override

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetterLog.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetterLog.java
@@ -1,0 +1,34 @@
+package gifterz.textme.domain.letter.entity;
+
+import gifterz.textme.domain.entity.BaseEntity;
+import gifterz.textme.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventLetterLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private EventLetter eventLetter;
+
+    public static EventLetterLog of(User user, EventLetter eventLetter) {
+        return new EventLetterLog(user, eventLetter);
+    }
+
+    private EventLetterLog(User user, EventLetter eventLetter) {
+        this.user = user;
+        this.eventLetter = eventLetter;
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetterLog.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetterLog.java
@@ -1,6 +1,7 @@
 package gifterz.textme.domain.letter.entity;
 
 import gifterz.textme.domain.entity.BaseEntity;
+import gifterz.textme.domain.entity.StatusType;
 import gifterz.textme.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -28,6 +29,7 @@ public class EventLetterLog extends BaseEntity {
     }
 
     private EventLetterLog(User user, EventLetter eventLetter) {
+        super(StatusType.ACTIVATE.getStatus());
         this.user = user;
         this.eventLetter = eventLetter;
     }

--- a/src/main/java/gifterz/textme/domain/letter/exception/AlreadyViewedUserException.java
+++ b/src/main/java/gifterz/textme/domain/letter/exception/AlreadyViewedUserException.java
@@ -1,0 +1,10 @@
+package gifterz.textme.domain.letter.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.ApplicationException;
+
+public class AlreadyViewedUserException extends ApplicationException {
+    public AlreadyViewedUserException() {
+        super("이미 조회한 사용자입니다.", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/exception/ExceedLetterViewCountException.java
+++ b/src/main/java/gifterz/textme/domain/letter/exception/ExceedLetterViewCountException.java
@@ -1,0 +1,12 @@
+package gifterz.textme.domain.letter.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.ApplicationException;
+
+import static gifterz.textme.domain.letter.entity.EventLetter.MAX_VIEW_COUNT;
+
+public class ExceedLetterViewCountException extends ApplicationException {
+    public ExceedLetterViewCountException() {
+        super("이미 " + MAX_VIEW_COUNT + "번 조회된 편지입니다.", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/exception/ExceedUserViewCountException.java
+++ b/src/main/java/gifterz/textme/domain/letter/exception/ExceedUserViewCountException.java
@@ -1,0 +1,13 @@
+package gifterz.textme.domain.letter.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.ApplicationException;
+
+import static gifterz.textme.domain.letter.entity.EventLetter.MAX_VIEW_COUNT;
+
+public class ExceedUserViewCountException extends ApplicationException {
+    public ExceedUserViewCountException() {
+        super("이미 " + MAX_VIEW_COUNT + "번 조회한 사용자입니다.", ErrorCode.ACCESS_DENIED);
+    }
+
+}

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
@@ -1,0 +1,15 @@
+package gifterz.textme.domain.letter.repository;
+
+import gifterz.textme.domain.letter.entity.EventLetterLog;
+import gifterz.textme.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional(readOnly = true)
+public interface EventLetterLogRepository extends JpaRepository<EventLetterLog, Long> {
+
+    @Query("select count(e) from EventLetterLog e where e.user = ?1")
+    long countByUser(User user);
+}

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
@@ -12,5 +12,5 @@ import java.util.Optional;
 public interface EventLetterRepository extends JpaRepository<EventLetter, Long> {
 
     @Lock(value = LockModeType.OPTIMISTIC)
-    Optional<EventLetter> findByIdWithOptimistic(Long id);
+    Optional<EventLetter> findByIdWithOptimistic(Long id, String status);
 }

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
@@ -4,6 +4,7 @@ import gifterz.textme.domain.letter.entity.EventLetter;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -12,5 +13,6 @@ import java.util.Optional;
 public interface EventLetterRepository extends JpaRepository<EventLetter, Long> {
 
     @Lock(value = LockModeType.OPTIMISTIC)
+    @Query("select e from EventLetter e where e.id = :id and e.status = :status")
     Optional<EventLetter> findByIdWithOptimistic(Long id, String status);
 }

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterRepository.java
@@ -1,9 +1,16 @@
 package gifterz.textme.domain.letter.repository;
 
 import gifterz.textme.domain.letter.entity.EventLetter;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Transactional(readOnly = true)
 public interface EventLetterRepository extends JpaRepository<EventLetter, Long> {
+
+    @Lock(value = LockModeType.OPTIMISTIC)
+    Optional<EventLetter> findByIdWithOptimistic(Long id);
 }

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -7,6 +7,8 @@ import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.entity.EventLetter;
 import gifterz.textme.domain.letter.entity.EventLetterLog;
 import gifterz.textme.domain.letter.exception.AlreadyViewedUserException;
+import gifterz.textme.domain.letter.exception.ExceedLetterViewCountException;
+import gifterz.textme.domain.letter.exception.ExceedUserViewCountException;
 import gifterz.textme.domain.letter.exception.LetterNotFoundException;
 import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
 import gifterz.textme.domain.letter.repository.EventLetterRepository;

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static gifterz.textme.domain.letter.entity.EventLetter.MAX_VIEW_COUNT;
 
 @Service
@@ -74,12 +76,12 @@ public class EventLetterService {
     private void checkUserViewCount(long viewCount) {
         if (viewCount >= 3) {
             throw new IllegalArgumentException("이미 3번 조회한 사용자입니다.");
+        if (viewCount >= MAX_VIEW_COUNT) {
+            throw new ExceedUserViewCountException();
         }
     }
 
     private void checkLetterViewCount(long viewCount) {
-        if (viewCount >= 3) {
-            throw new IllegalArgumentException("이미 3번 조회된 편지입니다.");
         if (viewCount >= MAX_VIEW_COUNT) {
             throw new ExceedLetterViewCountException();
         }

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import static gifterz.textme.domain.letter.entity.EventLetter.MAX_VIEW_COUNT;
 
 @Service
 @Transactional(readOnly = true)
@@ -79,6 +80,8 @@ public class EventLetterService {
     private void checkLetterViewCount(long viewCount) {
         if (viewCount >= 3) {
             throw new IllegalArgumentException("이미 3번 조회된 편지입니다.");
+        if (viewCount >= MAX_VIEW_COUNT) {
+            throw new ExceedLetterViewCountException();
         }
     }
 }

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -6,6 +6,7 @@ import gifterz.textme.domain.letter.dto.request.Target;
 import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.entity.EventLetter;
 import gifterz.textme.domain.letter.entity.EventLetterLog;
+import gifterz.textme.domain.letter.exception.AlreadyViewedUserException;
 import gifterz.textme.domain.letter.exception.LetterNotFoundException;
 import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
 import gifterz.textme.domain.letter.repository.EventLetterRepository;
@@ -48,6 +49,12 @@ public class EventLetterService {
         EventLetterLog eventLetterLog = EventLetterLog.of(user, eventLetter);
         eventLetterLogRepository.save(eventLetterLog);
         return EventLetterResponse.of(eventLetter);
+    }
+
+    private void checkAlreadyViewedUser(Long userId, Long letterId) {
+        if (viewMap.getOrDefault(letterId, new HashSet<>()).contains(userId)) {
+            throw new AlreadyViewedUserException();
+        }
     }
 
     private Optional<EventLetter> getEventLetterByIdWithOptimistic(Long letterId) {

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -1,5 +1,6 @@
 package gifterz.textme.domain.letter.service;
 
+import gifterz.textme.domain.entity.StatusType;
 import gifterz.textme.domain.letter.dto.request.SenderInfo;
 import gifterz.textme.domain.letter.dto.request.Target;
 import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
@@ -52,7 +53,7 @@ public class EventLetterService {
     private Optional<EventLetter> getEventLetterByIdWithOptimistic(Long letterId) {
         while (true) {
             try {
-                return eventLetterRepository.findByIdWithOptimistic(letterId);
+                return eventLetterRepository.findByIdWithOptimistic(letterId, StatusType.ACTIVATE.getStatus());
             } catch (ObjectOptimisticLockingFailureException e) {
                 log.info("현재 쓰레드: {}, letterId: {}", Thread.currentThread().getId(), letterId);
             }

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -2,20 +2,30 @@ package gifterz.textme.domain.letter.service;
 
 import gifterz.textme.domain.letter.dto.request.SenderInfo;
 import gifterz.textme.domain.letter.dto.request.Target;
+import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.entity.EventLetter;
+import gifterz.textme.domain.letter.entity.EventLetterLog;
+import gifterz.textme.domain.letter.exception.LetterNotFoundException;
+import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
 import gifterz.textme.domain.letter.repository.EventLetterRepository;
 import gifterz.textme.domain.user.entity.User;
 import gifterz.textme.domain.user.exception.UserNotFoundException;
 import gifterz.textme.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class EventLetterService {
     private final EventLetterRepository eventLetterRepository;
+    private final EventLetterLogRepository eventLetterLogRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -24,5 +34,41 @@ public class EventLetterService {
         EventLetter eventLetter = EventLetter.of(user, senderInfo.getSenderName(), letterInfo.getContents(),
                 letterInfo.getImageUrl(), senderInfo.getContactInfo());
         eventLetterRepository.save(eventLetter);
+    }
+
+    @Transactional
+    public synchronized EventLetterResponse findLetter(Long userId, Long letterId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        long userViewCount = eventLetterLogRepository.countByUser(user);
+        checkUserViewCount(userViewCount);
+        EventLetter eventLetter = getEventLetterByIdWithOptimistic(letterId).orElseThrow(LetterNotFoundException::new);
+        checkLetterViewCount(eventLetter.getViewCount());
+        eventLetter.increaseViewCount();
+        EventLetterLog eventLetterLog = EventLetterLog.of(user, eventLetter);
+        eventLetterLogRepository.save(eventLetterLog);
+        return EventLetterResponse.of(eventLetter);
+    }
+
+    private Optional<EventLetter> getEventLetterByIdWithOptimistic(Long letterId) {
+        while (true) {
+            try {
+                return eventLetterRepository.findByIdWithOptimistic(letterId);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.info("현재 쓰레드: {}, letterId: {}", Thread.currentThread().getId(), letterId);
+            }
+        }
+
+    }
+
+    private void checkUserViewCount(long viewCount) {
+        if (viewCount >= 3) {
+            throw new IllegalArgumentException("이미 3번 조회한 사용자입니다.");
+        }
+    }
+
+    private void checkLetterViewCount(long viewCount) {
+        if (viewCount >= 3) {
+            throw new IllegalArgumentException("이미 3번 조회된 편지입니다.");
+        }
     }
 }

--- a/src/main/java/gifterz/textme/error/ApplicationExceptionHandler.java
+++ b/src/main/java/gifterz/textme/error/ApplicationExceptionHandler.java
@@ -25,9 +25,10 @@ public class ApplicationExceptionHandler {
 
     @ExceptionHandler
     protected ResponseEntity<ErrorResponse> handleApplicationException(final ApplicationException err) {
-        log.error("handleEntityNotFoundException", err);
+        log.error("handleApplicationException", err);
         final ErrorCode errorCode = err.getErrorCode();
         final ErrorResponse response = ErrorResponse.from(errorCode);
+        response.changeMessage(err.getMessage());
         return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getHttpStatus()));
     }
 

--- a/src/main/java/gifterz/textme/global/config/DataSourceConfig.java
+++ b/src/main/java/gifterz/textme/global/config/DataSourceConfig.java
@@ -1,0 +1,25 @@
+package gifterz.textme.global.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    @Primary
+    @ConfigurationProperties("spring.datasource")
+    public DataSourceProperties dataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.hikari")
+    public HikariDataSource dataSource(DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      pool-name: HikariCP
+      maximum-pool-size: 10
+      minimum-idle: 5
+      idle-timeout: 3000
+      connection-timeout: 3000
+      validation-timeout: 3000
+      max-lifetime: 180000
   redis:
     cache:
       host: ${REDIS_HOST}
@@ -77,7 +85,16 @@ oauth:
     api:
       base_url: ${DKU_BASE_URL}
       authorize: ${DKU_AUTHORIZE_API}
+
+batch:
+  view-count:
+    delay: 10000
+
+
 logging:
   level:
     org.springframework.core:
       LocalVariableTableParameterNameDiscoverer: error
+    org.hibernate.SQL: info
+    root: info
+    com.zaxxer.hikari.pool.HikariPool: debug

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -2,6 +2,7 @@ package gifterz.textme.domain.letter.service;
 
 import gifterz.textme.domain.letter.dto.request.SenderInfo;
 import gifterz.textme.domain.letter.dto.request.Target;
+import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.entity.EventLetter;
 import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
 import gifterz.textme.domain.letter.repository.EventLetterRepository;
@@ -20,6 +21,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -62,6 +64,26 @@ class EventLetterServiceTest {
         verify(eventLetterRepository, times(1)).save(eventLetterArgumentCaptor.capture());
         EventLetter savedEventLetter = eventLetterArgumentCaptor.getValue();
         assertEquals(expectedEventLetter, savedEventLetter);
+    }
+
+    @Test
+    void getEventLetter() {
+        // Given
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(eventLetterRepository.findById(any())).thenReturn(Optional.of(eventLetter));
+        when(eventLetterLogRepository.countByUser(any())).thenReturn(0L);
+
+        // When
+        EventLetterResponse response = eventLetterService.findLetter(user.getId(), eventLetter.getId());
+
+        // Then
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(eventLetter.getId()),
+                () -> assertThat(response.senderName()).isEqualTo(eventLetter.getSenderName()),
+                () -> assertThat(response.contents()).isEqualTo(eventLetter.getContents()),
+                () -> assertThat(response.imageUrl()).isEqualTo(eventLetter.getImageUrl()),
+                () -> assertThat(response.contactInfo()).isEqualTo(eventLetter.getContactInfo())
+        );
     }
 
 }

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -1,5 +1,6 @@
 package gifterz.textme.domain.letter.service;
 
+import gifterz.textme.domain.entity.StatusType;
 import gifterz.textme.domain.letter.dto.request.SenderInfo;
 import gifterz.textme.domain.letter.dto.request.Target;
 import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
@@ -126,7 +127,7 @@ class EventLetterServiceTest {
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
-        when(eventLetterRepository.findByIdWithOptimistic(any())).thenReturn(Optional.of(eventLetter));
+        when(eventLetterRepository.findByIdWithOptimistic(any(), StatusType.ACTIVATE.getStatus())).thenReturn(Optional.of(eventLetter));
         // when
         for (int i = 0; i < threadCount; i++) {
             executorService.submit(() -> {

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -86,4 +86,17 @@ class EventLetterServiceTest {
         );
     }
 
+    @Test
+    void getEventLetterWithUserViewCountOver3() {
+        // Given
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(eventLetterLogRepository.countByUser(any())).thenReturn(3L);
+
+        // When, Then
+        assertThrows(IllegalArgumentException.class,
+                () -> eventLetterService.findLetter(user.getId(), eventLetter.getId()),
+                "이미 3번 이상 조회한 사용자입니다."
+        );
+    }
+
 }

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -1,0 +1,67 @@
+package gifterz.textme.domain.letter.service;
+
+import gifterz.textme.domain.letter.dto.request.SenderInfo;
+import gifterz.textme.domain.letter.dto.request.Target;
+import gifterz.textme.domain.letter.entity.EventLetter;
+import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
+import gifterz.textme.domain.letter.repository.EventLetterRepository;
+import gifterz.textme.domain.oauth.entity.AuthType;
+import gifterz.textme.domain.user.entity.Major;
+import gifterz.textme.domain.user.entity.User;
+import gifterz.textme.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
+class EventLetterServiceTest {
+
+    @InjectMocks
+    private EventLetterService eventLetterService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EventLetterRepository eventLetterRepository;
+    @Mock
+    private EventLetterLogRepository eventLetterLogRepository;
+    private User user;
+    private EventLetter eventLetter;
+
+    @BeforeEach
+    void setUp() {
+        Major major = Major.of("department", "major");
+        user = User.of("email", "name", AuthType.PASSWORD, major, "남자");
+        eventLetter = EventLetter.of(user, "senderName", "contents", "imageUrl", "contactInfo");
+    }
+
+    @Test
+    void sendEventLetter() {
+        // Given
+        SenderInfo senderInfo = SenderInfo.builder().senderName("name").contactInfo("contact").build();
+        Target letterInfo = Target.of("contents", "imageUrl");
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        EventLetter expectedEventLetter = EventLetter.of(user, senderInfo.getSenderName(), letterInfo.getContents(),
+                letterInfo.getImageUrl(), senderInfo.getContactInfo());
+
+        // When
+        eventLetterService.sendLetter(user.getId(), senderInfo, letterInfo);
+
+        // Then
+        ArgumentCaptor<EventLetter> eventLetterArgumentCaptor = ArgumentCaptor.forClass(EventLetter.class);
+        verify(eventLetterRepository, times(1)).save(eventLetterArgumentCaptor.capture());
+        EventLetter savedEventLetter = eventLetterArgumentCaptor.getValue();
+        assertEquals(expectedEventLetter, savedEventLetter);
+    }
+
+}

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -99,4 +99,21 @@ class EventLetterServiceTest {
         );
     }
 
+    @Test
+    void getEventLetterWithLetterViewCountOver3() {
+        // Given
+        EventLetter eventLetter = EventLetter.of(user, "senderName", "contents", "imageUrl", "contactInfo");
+        eventLetter.increaseViewCount();
+        eventLetter.increaseViewCount();
+        eventLetter.increaseViewCount();
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(eventLetterLogRepository.countByUser(any())).thenReturn(0L);
+        when(eventLetterRepository.findById(any())).thenReturn(Optional.of(eventLetter));
+
+        // When, Then
+        assertThrows(IllegalArgumentException.class,
+                () -> eventLetterService.findLetter(user.getId(), eventLetter.getId()),
+                "이미 3번 조회된 편지입니다.");
+    }
+
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource :
+    url: jdbc:h2:mem:test
+    driverClassName: org.h2.Driver
+    username:
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
related #29
 
## 작업사항
- 3회 미만으로 조회된 편지만 조회할 수 있음.
- 사용자는 서로 다른 편지 3회만 조회할 수 있음.
- 낙관적 락 사용하여 동시성 지원(-> 추후 쓰레드 간 race condition 많으면 pessimisitic으로 리팩토링 예정)
- EventLetter 관련 테스트 코드 작성
###  추가
- HikariCP 세부 설정 값 명시
- ApplicationException 세부 에러 메세지 리턴