### PR TITLE
Feature: DTM-56-split-check-authority

### DIFF
--- a/src/main/java/gifterz/textme/domain/admin/controller/AdminController.java
+++ b/src/main/java/gifterz/textme/domain/admin/controller/AdminController.java
@@ -1,0 +1,38 @@
+package gifterz.textme.domain.admin.controller;
+
+import gifterz.textme.domain.letter.dto.response.AdminEventLetterResponse;
+import gifterz.textme.domain.letter.service.EventLetterService;
+import gifterz.textme.global.auth.role.AdminAuth;
+import gifterz.textme.global.security.jwt.JwtAuthentication;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController {
+    private final EventLetterService eventLetterService;
+
+    @AdminAuth
+    @GetMapping("/letters/events/all")
+    public ResponseEntity<List<AdminEventLetterResponse>> findAllLettersByStatus(
+            JwtAuthentication auth,
+            @RequestParam(required = false) String status
+    ) {
+        List<AdminEventLetterResponse> letterResponses = eventLetterService.findAllLettersByStatus(status);
+        return ResponseEntity.ok().body(letterResponses);
+    }
+
+    @AdminAuth
+    @PatchMapping("/letters/events/{letterId}/{status}")
+    public ResponseEntity<Void> changeLetterStatus(JwtAuthentication auth,
+                                                   @PathVariable("letterId") final Long letterId,
+                                                   @PathVariable("status") String status) {
+        eventLetterService.changeLetterStatus(letterId, status);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
+++ b/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
@@ -1,7 +1,6 @@
 package gifterz.textme.domain.letter.controller;
 
 import gifterz.textme.domain.letter.dto.request.EventLetterRequest;
-import gifterz.textme.domain.letter.dto.response.AdminEventLetterResponse;
 import gifterz.textme.domain.letter.dto.response.AllEventLetterResponse;
 import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.service.EventLetterService;

--- a/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
+++ b/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
@@ -54,25 +54,6 @@ public class EventLetterController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @GetMapping("/admin/all")
-    @AdminAuth
-    public ResponseEntity<List<AdminEventLetterResponse>> findAllLettersByStatus(
-            JwtAuthentication auth,
-            @RequestParam(required = false) String status
-    ) {
-        List<AdminEventLetterResponse> letterResponses = eventLetterService.findAllLettersByStatus(status);
-        return ResponseEntity.ok().body(letterResponses);
-    }
-
-    @PatchMapping("/{letterId}/{status}")
-    @AdminAuth
-    public ResponseEntity<Void> changeLetterStatus(JwtAuthentication auth,
-                                                   @PathVariable("letterId") final Long letterId,
-                                                   @PathVariable("status") String status) {
-        eventLetterService.changeLetterStatus(letterId, status);
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
-
     @GetMapping("/user")
     @UserAuth
     public ResponseEntity<List<EventLetterResponse>> findLettersByUser(JwtAuthentication auth) {

--- a/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
+++ b/src/main/java/gifterz/textme/domain/letter/controller/EventLetterController.java
@@ -5,8 +5,7 @@ import gifterz.textme.domain.letter.dto.response.AdminEventLetterResponse;
 import gifterz.textme.domain.letter.dto.response.AllEventLetterResponse;
 import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
 import gifterz.textme.domain.letter.service.EventLetterService;
-import gifterz.textme.global.auth.role.AdminAuth;
-import gifterz.textme.global.auth.role.UserAuth;
+import gifterz.textme.global.auth.role.DkuAuth;
 import gifterz.textme.global.security.jwt.JwtAuthentication;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +22,14 @@ public class EventLetterController {
     private final EventLetterService eventLetterService;
 
     @PostMapping
-    @UserAuth
+    @DkuAuth
     public ResponseEntity<Void> sendLetter(JwtAuthentication auth, @RequestBody @Valid EventLetterRequest request) {
         eventLetterService.sendLetter(auth.getUserId(), request.toSenderInfo(), request.toTarget());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping
-    @UserAuth
+    @DkuAuth
     public ResponseEntity<List<AllEventLetterResponse>> getLettersByGender(
             JwtAuthentication auth,
             @RequestParam(required = false) String gender
@@ -40,7 +39,7 @@ public class EventLetterController {
     }
 
     @GetMapping("/{id}")
-    @UserAuth
+    @DkuAuth
     public ResponseEntity<EventLetterResponse> findLetter(JwtAuthentication auth,
                                                           @PathVariable("id") final Long letterId) {
         EventLetterResponse response = eventLetterService.findLetter(auth.getUserId(), letterId);
@@ -48,14 +47,14 @@ public class EventLetterController {
     }
 
     @PostMapping("/{letterId}/reports")
-    @UserAuth
+    @DkuAuth
     public ResponseEntity<Void> reportLetter(JwtAuthentication auth, @PathVariable("letterId") final Long letterId) {
         eventLetterService.reportLetter(letterId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @GetMapping("/user")
-    @UserAuth
+    @DkuAuth
     public ResponseEntity<List<EventLetterResponse>> findLettersByUser(JwtAuthentication auth) {
         List<EventLetterResponse> responses = eventLetterService.findLettersByUser(auth.getUserId());
         return ResponseEntity.ok().body(responses);

--- a/src/main/java/gifterz/textme/domain/user/controller/UserController.java
+++ b/src/main/java/gifterz/textme/domain/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package gifterz.textme.domain.user.controller;
 
 import gifterz.textme.common.firebase.FCMService;
-import gifterz.textme.global.auth.role.AdminAuth;
 import gifterz.textme.global.auth.role.UserAuth;
 import gifterz.textme.global.security.jwt.JwtAuthentication;
 import gifterz.textme.global.security.service.RefreshTokenService;

--- a/src/main/java/gifterz/textme/error/exception/NoAuthorizationException.java
+++ b/src/main/java/gifterz/textme/error/exception/NoAuthorizationException.java
@@ -1,0 +1,10 @@
+package gifterz.textme.error.exception;
+
+import gifterz.textme.error.ErrorCode;
+
+public class NoAuthorizationException extends ApplicationException {
+
+    public NoAuthorizationException(String message) {
+        super(message, ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/gifterz/textme/global/auth/aspect/AuthTypeCheckAspect.java
+++ b/src/main/java/gifterz/textme/global/auth/aspect/AuthTypeCheckAspect.java
@@ -1,0 +1,33 @@
+package gifterz.textme.global.auth.aspect;
+
+import gifterz.textme.domain.oauth.entity.AuthType;
+import gifterz.textme.error.exception.NoAuthorizationException;
+import gifterz.textme.global.auth.role.UserRole;
+import gifterz.textme.global.security.jwt.JwtAuthentication;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class AuthTypeCheckAspect {
+
+    @Before("gifterz.textme.global.auth.pointcut.Pointcuts.dkuAuth()")
+    public void checkDkuAuth(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof JwtAuthentication authentication) {
+                if (hasDkuAuth(authentication.getUserRole(), authentication.getAuthType())) return;
+                throw new NoAuthorizationException("DKU 로그인 시에만 접근 가능합니다.");
+            }
+        }
+    }
+
+    private static boolean hasDkuAuth(UserRole userRole, AuthType authType) {
+        if (userRole == UserRole.USER || userRole == UserRole.ADMIN) {
+            return authType == AuthType.DKU;
+        }
+        return false;
+    }
+}

--- a/src/main/java/gifterz/textme/global/auth/aspect/RoleCheckAspect.java
+++ b/src/main/java/gifterz/textme/global/auth/aspect/RoleCheckAspect.java
@@ -1,0 +1,32 @@
+package gifterz.textme.global.auth.aspect;
+
+import gifterz.textme.error.exception.NoAuthorizationException;
+import gifterz.textme.global.auth.role.UserRole;
+import gifterz.textme.global.security.jwt.JwtAuthentication;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class RoleCheckAspect {
+
+    @Before("gifterz.textme.global.auth.pointcut.Pointcuts.userAuth()")
+    public void checkUserAuth(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof JwtAuthentication authentication) {
+                if (hasAuthority(authentication.getUserRole())) {
+                    return;
+                }
+                throw new NoAuthorizationException("사용자 권한이 없습니다.");
+            }
+        }
+    }
+
+    private static boolean hasAuthority(UserRole userRole) {
+        return userRole == UserRole.USER || userRole == UserRole.ADMIN;
+    }
+
+}

--- a/src/main/java/gifterz/textme/global/auth/aspect/RoleCheckAspect.java
+++ b/src/main/java/gifterz/textme/global/auth/aspect/RoleCheckAspect.java
@@ -29,4 +29,20 @@ public class RoleCheckAspect {
         return userRole == UserRole.USER || userRole == UserRole.ADMIN;
     }
 
+    @Before("gifterz.textme.global.auth.pointcut.Pointcuts.adminAuth()")
+    public void checkAdminAuth(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof JwtAuthentication authentication) {
+                if (hasAdminAuth(authentication.getUserRole())) {
+                    return;
+                }
+                throw new NoAuthorizationException("관리자 권한이 없습니다.");
+            }
+        }
+    }
+
+    private static boolean hasAdminAuth(UserRole userRole) {
+        return userRole == UserRole.ADMIN;
+    }
 }

--- a/src/main/java/gifterz/textme/global/auth/pointcut/Pointcuts.java
+++ b/src/main/java/gifterz/textme/global/auth/pointcut/Pointcuts.java
@@ -1,0 +1,27 @@
+package gifterz.textme.global.auth.pointcut;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+    @Pointcut("@annotation(gifterz.textme.global.auth.role.UserAuth)")
+    public void userAuth() {
+    }
+
+    @Pointcut("@annotation(gifterz.textme.global.auth.role.AdminAuth)")
+    public void adminAuth() {
+    }
+
+    @Pointcut("userAuth() || adminAuth()")
+    public void userOrAdminAuth() {
+    }
+
+    @Pointcut("@annotation(gifterz.textme.global.auth.role.DkuAuth)")
+    public void dkuAuth() {
+    }
+
+    @Pointcut("dkuAuth() && userOrAdminAuth()")
+    public void eventAndUserOrAdminAuth() {
+    }
+
+}

--- a/src/main/java/gifterz/textme/global/auth/role/DkuAuth.java
+++ b/src/main/java/gifterz/textme/global/auth/role/DkuAuth.java
@@ -1,0 +1,10 @@
+package gifterz.textme.global.auth.role;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DkuAuth {
+
+}

--- a/src/main/java/gifterz/textme/global/config/WebSecurityConfig.java
+++ b/src/main/java/gifterz/textme/global/config/WebSecurityConfig.java
@@ -52,7 +52,6 @@ public class WebSecurityConfig {
                 .addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth.requestMatchers(PUBLIC_URI)
                         .permitAll()
-                        .requestMatchers(ADMIN_URI).hasAuthority(UserRole.ROLE_ADMIN)
                         .anyRequest().authenticated())
                 .build();
     }

--- a/src/main/java/gifterz/textme/global/security/jwt/JwtAuthentication.java
+++ b/src/main/java/gifterz/textme/global/security/jwt/JwtAuthentication.java
@@ -1,5 +1,6 @@
 package gifterz.textme.global.security.jwt;
 
+import gifterz.textme.domain.oauth.entity.AuthType;
 import gifterz.textme.global.auth.role.UserRole;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -15,6 +16,7 @@ public class JwtAuthentication implements Authentication {
     private Long userId;
     private String email;
     private UserRole userRole;
+    private AuthType authType;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -33,6 +35,10 @@ public class JwtAuthentication implements Authentication {
 
     public UserRole getUserRole() {
         return userRole;
+    }
+
+    public AuthType getAuthType() {
+        return authType;
     }
 
     @Override

--- a/src/main/java/gifterz/textme/global/security/jwt/JwtUtils.java
+++ b/src/main/java/gifterz/textme/global/security/jwt/JwtUtils.java
@@ -1,5 +1,6 @@
 package gifterz.textme.global.security.jwt;
 
+import gifterz.textme.domain.oauth.entity.AuthType;
 import gifterz.textme.domain.user.entity.User;
 import gifterz.textme.global.auth.role.UserRole;
 import io.jsonwebtoken.*;
@@ -30,6 +31,7 @@ public class JwtUtils {
         claims.put("userId", user.getId());
         claims.put("email", user.getEmail());
         claims.put("role", user.getUserRole());
+        claims.put("authType", user.getAuthType());
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -63,7 +65,8 @@ public class JwtUtils {
         Long userId = claims.get("userId", Long.class);
         String email = claims.get("email", String.class);
         String userRole = claims.get("role", String.class);
-        return new JwtAuthentication(userId, email, UserRole.valueOf(userRole));
+        String authType = claims.get("authType", String.class);
+        return new JwtAuthentication(userId, email, UserRole.valueOf(userRole), AuthType.valueOf(authType));
 
     }
 


### PR DESCRIPTION
related #56 

## 작업사항
- DkuAuth 어노테이션 추가
- 권한확인 적용할 곳 명시 위해 pointCut 추가
- RoleCheckAspect 추가
- 권한 없을 때, Access-Denied 반환과 함께 커스텀 메세지 전송 위해 NoAuthorizationException 추가
- JwtAccessToken claim에 사용자 authType을 추가
- JwtAuthentication에 AuthType 필드와 해당 필드의 getter메서드 추가
- 필터에서 더 이상 /admin으로 들어오는 메세지에 대해 권한 확인 안함
- UserController 내 사용 안하는 import(AdminAuth) 제거
- 관리자 사용 API를 위해 AdminController 추가
- Dku 소셜로그인인지 확인하는 Aspect 추가
- 이벤트 편지 관련 API에 대해 사용자 권한이 있고, AuthType이 DKU인지 확인하도록 UserAuth 대신 DkuAuth 추가
- 사용하지 않는 import 제거