### PR TITLE
Refactor: DTM-54-find-letters-already-saw

### DIFF
--- a/src/main/java/gifterz/textme/domain/letter/exception/NotPostedUserException.java
+++ b/src/main/java/gifterz/textme/domain/letter/exception/NotPostedUserException.java
@@ -1,0 +1,10 @@
+package gifterz.textme.domain.letter.exception;
+
+import gifterz.textme.error.ErrorCode;
+import gifterz.textme.error.exception.ApplicationException;
+
+public class NotPostedUserException extends ApplicationException {
+    public NotPostedUserException() {
+        super("편지를 작성하지 않은 사용자는 편지를 볼 수 없습니다.", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
@@ -1,7 +1,6 @@
 package gifterz.textme.domain.letter.repository;
 
 import gifterz.textme.domain.letter.entity.EventLetterLog;
-import gifterz.textme.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +11,4 @@ import java.util.List;
 public interface EventLetterLogRepository extends JpaRepository<EventLetterLog, Long> {
 
     List<EventLetterLog> findAllByUserId(Long userId);
-
-    List<EventLetterLog> findByUser(User user);
 }

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
@@ -15,4 +15,6 @@ public interface EventLetterLogRepository extends JpaRepository<EventLetterLog, 
     long countByUser(User user);
 
     List<EventLetterLog> findAllByUserId(Long userId);
+
+    List<EventLetterLog> findByUser(User user);
 }

--- a/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
+++ b/src/main/java/gifterz/textme/domain/letter/repository/EventLetterLogRepository.java
@@ -3,7 +3,6 @@ package gifterz.textme.domain.letter.repository;
 import gifterz.textme.domain.letter.entity.EventLetterLog;
 import gifterz.textme.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -11,8 +10,6 @@ import java.util.List;
 
 @Transactional(readOnly = true)
 public interface EventLetterLogRepository extends JpaRepository<EventLetterLog, Long> {
-
-    long countByUser(User user);
 
     List<EventLetterLog> findAllByUserId(Long userId);
 

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -78,7 +78,7 @@ public class EventLetterService {
     @Transactional
     public WhoseEventLetterResponse findLetter(Long userId, Long letterId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        checkAlreadyViewedUser(userId, letterId);
+        EventLetter myEventLetter = eventLetterRepository.findByUser(user).orElseThrow(NotPostedUserException::new);
 
         long userViewCount = eventLetterLogRepository.countByUser(user);
         checkUserViewCount(userViewCount);

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -35,7 +35,6 @@ public class EventLetterService {
     private final EventLetterRepository eventLetterRepository;
     private final EventLetterLogRepository eventLetterLogRepository;
     private final UserRepository userRepository;
-    public static ConcurrentHashMap<Long, HashSet<Long>> viewMap = new ConcurrentHashMap<>();
 
     @Transactional
     public void sendLetter(Long senderId, SenderInfo senderInfo, Target letterInfo) {

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -21,8 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.HashSet;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
 import static gifterz.textme.domain.entity.StatusType.ACTIVATE;
 import static gifterz.textme.domain.entity.StatusType.PENDING;
@@ -91,6 +90,9 @@ public class EventLetterService {
         if (myEventLetter.equals(eventLetter)) {
             return WhoseEventLetterResponse.of(eventLetter, true);
         }
+
+        checkIsViewedEventLetter(viewedLogs, eventLetter);
+
         eventLetter.increaseViewCount();
 
         EventLetterLog eventLetterLog = EventLetterLog.of(user, eventLetter);
@@ -99,10 +101,14 @@ public class EventLetterService {
         return WhoseEventLetterResponse.of(eventLetter, false);
     }
 
-    private void checkAlreadyViewedUser(Long userId, Long letterId) {
-        if (viewMap.getOrDefault(letterId, new HashSet<>()).contains(userId)) {
-            throw new AlreadyViewedUserException();
-        }
+    private void checkIsViewedEventLetter(List<EventLetterLog> viewedLogs, EventLetter eventLetter) {
+        viewedLogs.forEach(eventLetterLog -> {
+            EventLetter viewedEventLetter = eventLetterLog.getEventLetter();
+            Long viewedEventLetterId = viewedEventLetter.getId();
+            if (Objects.equals(eventLetter.getId(), viewedEventLetterId)) {
+                throw new AlreadyViewedUserException();
+            }
+        });
     }
 
     private void checkUserViewCount(long viewCount) {

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -80,7 +80,8 @@ public class EventLetterService {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         EventLetter myEventLetter = eventLetterRepository.findByUser(user).orElseThrow(NotPostedUserException::new);
 
-        long userViewCount = eventLetterLogRepository.countByUser(user);
+        List<EventLetterLog> viewedLogs = eventLetterLogRepository.findByUser(user);
+        long userViewCount = viewedLogs.size();
         checkUserViewCount(userViewCount);
 
         EventLetter eventLetter = eventLetterRepository

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -79,7 +79,7 @@ public class EventLetterService {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         EventLetter myEventLetter = eventLetterRepository.findByUser(user).orElseThrow(NotPostedUserException::new);
 
-        List<EventLetterLog> viewedLogs = eventLetterLogRepository.findByUser(user);
+        List<EventLetterLog> viewedLogs = eventLetterLogRepository.findAllByUserId(userId);
         long userViewCount = viewedLogs.size();
         checkUserViewCount(userViewCount);
 

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -87,7 +87,7 @@ public class EventLetterService {
                 .findByIdWithPessimistic(letterId, ACTIVATE.getStatus()).orElseThrow(LetterNotFoundException::new);
         checkLetterViewCount(eventLetter.getViewCount());
 
-        if (eventLetter.getUser() == user) {
+        if (myEventLetter.equals(eventLetter)) {
             return WhoseEventLetterResponse.of(eventLetter, true);
         }
         eventLetter.increaseViewCount();

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -182,10 +182,13 @@ class EventLetterServiceTest {
     @Test
     void findEventLetterThatIsMine() {
         // Given
-        when(eventLetterRepository.findByIdWithPessimistic(any(), any())).thenReturn(Optional.of(eventLetter));
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
+        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
+        when(eventLetterRepository.findByIdWithPessimistic(any(), any())).thenReturn(Optional.of(eventLetter));
+
         // When
-        EventLetterResponse response = eventLetterService.findLetter(1L, 1L);
+        WhoseEventLetterResponse response = eventLetterService.findLetter(1L, 1L);
 
         // Then
         assertThat(response).isNotNull();

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -83,14 +83,13 @@ class EventLetterServiceTest {
     @Test
     void getEventLetter() {
         // Given
-        viewMap.put(1L, new HashSet<>());
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
         when(eventLetterRepository.findByIdWithPessimistic(1L, StatusType.ACTIVATE.getStatus()))
                 .thenReturn(Optional.of(eventLetter));
-        when(eventLetterLogRepository.countByUser(user)).thenReturn(0L);
 
         // When
-        EventLetterResponse response = eventLetterService.findLetter(1L, 1L);
+        WhoseEventLetterResponse response = eventLetterService.findLetter(1L, 1L);
 
         // Then
         assertAll(

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static gifterz.textme.domain.letter.entity.EventLetter.MAX_VIEW_COUNT;
-import static gifterz.textme.domain.letter.service.EventLetterService.viewMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -61,11 +60,6 @@ class EventLetterServiceTest {
                 "imageUrl", "contactInfo");
         eventLetterLog = EventLetterLog.of(user, eventLetter);
         eventLetterLogs.add(eventLetterLog);
-    }
-
-    @AfterEach()
-    void clearViewMap() {
-        viewMap.clear();
     }
 
     @Test
@@ -127,12 +121,14 @@ class EventLetterServiceTest {
     @Test
     void getEventLetterWithLetterViewCountOver3() {
         // Given
-        EventLetter eventLetter = EventLetter.of(user, "senderName", "contents", "imageUrl", "contactInfo");
+        EventLetter eventLetter = EventLetter.of(user, "senderName", "contents",
+                "imageUrl", "contactInfo");
         eventLetter.increaseViewCount();
         eventLetter.increaseViewCount();
         eventLetter.increaseViewCount();
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
-        when(eventLetterLogRepository.countByUser(any())).thenReturn(0L);
+        when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
+        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
         when(eventLetterRepository.findByIdWithPessimistic(any(), any())).thenReturn(Optional.of(eventLetter));
 
         // When, Then

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -3,8 +3,9 @@ package gifterz.textme.domain.letter.service;
 import gifterz.textme.domain.entity.StatusType;
 import gifterz.textme.domain.letter.dto.request.SenderInfo;
 import gifterz.textme.domain.letter.dto.request.Target;
-import gifterz.textme.domain.letter.dto.response.EventLetterResponse;
+import gifterz.textme.domain.letter.dto.response.WhoseEventLetterResponse;
 import gifterz.textme.domain.letter.entity.EventLetter;
+import gifterz.textme.domain.letter.entity.EventLetterLog;
 import gifterz.textme.domain.letter.repository.EventLetterLogRepository;
 import gifterz.textme.domain.letter.repository.EventLetterRepository;
 import gifterz.textme.domain.oauth.entity.AuthType;
@@ -12,7 +13,6 @@ import gifterz.textme.domain.user.entity.Major;
 import gifterz.textme.domain.user.entity.User;
 import gifterz.textme.domain.user.repository.UserRepository;
 import gifterz.textme.error.exception.ApplicationException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,7 +22,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.TestPropertySource;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -48,12 +49,18 @@ class EventLetterServiceTest {
     private EventLetterLogRepository eventLetterLogRepository;
     private User user;
     private EventLetter eventLetter;
+    private EventLetterLog eventLetterLog;
+
+    private List<EventLetterLog> eventLetterLogs = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
         Major major = Major.of("department", "major");
         user = User.of("email", "name", AuthType.PASSWORD, major, "남자");
-        eventLetter = EventLetter.of(user, "senderName", "contents", "imageUrl", "contactInfo");
+        eventLetter = EventLetter.of(user, "senderName", "contents",
+                "imageUrl", "contactInfo");
+        eventLetterLog = EventLetterLog.of(user, eventLetter);
+        eventLetterLogs.add(eventLetterLog);
     }
 
     @AfterEach()
@@ -104,8 +111,11 @@ class EventLetterServiceTest {
     @Test
     void getEventLetterWithUserViewCountOver3() {
         // Given
+        eventLetterLogs.add(eventLetterLog);
+        eventLetterLogs.add(eventLetterLog);
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
-        when(eventLetterLogRepository.countByUser(any())).thenReturn(3L);
+        when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
+        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
 
         // When, Then
         assertThrows(ApplicationException.class,

--- a/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
+++ b/src/test/java/gifterz/textme/domain/letter/service/EventLetterServiceTest.java
@@ -109,7 +109,7 @@ class EventLetterServiceTest {
         eventLetterLogs.add(eventLetterLog);
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
-        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
+        when(eventLetterLogRepository.findAllByUserId(any())).thenReturn(eventLetterLogs);
 
         // When, Then
         assertThrows(ApplicationException.class,
@@ -128,7 +128,7 @@ class EventLetterServiceTest {
         eventLetter.increaseViewCount();
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
-        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
+        when(eventLetterLogRepository.findAllByUserId(any())).thenReturn(eventLetterLogs);
         when(eventLetterRepository.findByIdWithPessimistic(any(), any())).thenReturn(Optional.of(eventLetter));
 
         // When, Then
@@ -184,7 +184,7 @@ class EventLetterServiceTest {
         // Given
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(eventLetterRepository.findByUser(user)).thenReturn(Optional.of(eventLetter));
-        when(eventLetterLogRepository.findByUser(user)).thenReturn(eventLetterLogs);
+        when(eventLetterLogRepository.findAllByUserId(any())).thenReturn(eventLetterLogs);
         when(eventLetterRepository.findByIdWithPessimistic(any(), any())).thenReturn(Optional.of(eventLetter));
 
         // When


### PR DESCRIPTION
related #54 

##작업사항
- findLetter 시 사용자가 편지 전송하지 않았다면 NotPostedUserException 처리
- 새로 조회한 편지가 이전에 조회한 사용자인지 확인 로직 viewMap 사용 -> DB에서 log 조회하여 log와 맵핑되는 EventLetter가 있을 때, AlreadyViewedUserException 처리