### PR TITLE
refactor: DTM-72-이벤트 편지에 isEvent 필드 추가

### DIFF
--- a/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
+++ b/src/main/java/gifterz/textme/domain/letter/entity/EventLetter.java
@@ -37,15 +37,17 @@ public class EventLetter extends BaseEntity {
 
     private Integer viewCount;
 
+    private Boolean isEvent;
+
     public final static int MAX_VIEW_COUNT = 3;
 
     public static EventLetter of(User user, String senderName, String contents,
                                  String imageUrl, String contactInfo) {
-        return new EventLetter(user, senderName, contents, imageUrl, contactInfo, 0);
+        return new EventLetter(user, senderName, contents, imageUrl, contactInfo, 0, false);
     }
 
     private EventLetter(User user, String senderName, String contents,
-                        String imageUrl, String contactInfo, Integer viewCount) {
+                        String imageUrl, String contactInfo, Integer viewCount, Boolean isEvent) {
         super(StatusType.ACTIVATE.getStatus());
         this.user = user;
         this.senderName = senderName;
@@ -53,6 +55,7 @@ public class EventLetter extends BaseEntity {
         this.imageUrl = imageUrl;
         this.contactInfo = contactInfo;
         this.viewCount = viewCount;
+        this.isEvent = isEvent;
     }
 
     public void increaseViewCount() {

--- a/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
+++ b/src/main/java/gifterz/textme/domain/letter/service/EventLetterService.java
@@ -88,7 +88,7 @@ public class EventLetterService {
         EventLetter myEventLetter = eventLetterRepository.findByUser(user).orElseThrow(NotPostedUserException::new);
 
         List<EventLetterLog> viewedLogs = eventLetterLogRepository.findAllByUserId(userId);
-        long userViewCount = viewedLogs.size();
+        long userViewCount = viewCountWithoutEvent(viewedLogs);
         checkUserViewCount(userViewCount);
 
         EventLetter eventLetter = eventLetterRepository
@@ -107,6 +107,12 @@ public class EventLetterService {
         eventLetterLogRepository.save(eventLetterLog);
 
         return WhoseEventLetterResponse.of(eventLetter, false);
+    }
+
+    private long viewCountWithoutEvent(List<EventLetterLog> viewedLogs) {
+        return viewedLogs.stream()
+                .filter(eventLetterLog -> !eventLetterLog.getEventLetter().getIsEvent())
+                .count();
     }
 
     private void checkIsViewedEventLetter(List<EventLetterLog> viewedLogs, EventLetter eventLetter) {


### PR DESCRIPTION
related #72 

## 작업사항
- EventLetter에 isEvent 필드 추가
- 이벤트 페이지 속 이벤트에 당첨 시 viewCount가 늘어나지 않게 리팩토링.
- 사용자 당 한 번의 이벤트만 당첨되도록 편지 전체 조회에서
	1. 이벤트 당첨자는 또 다른 이벤트 편지가 보이고, 자신의 편지는 보이지 않도록 필터링
	2. 이벤트 미당첨자는 이벤트 편지와 자신의 편지가 보이지 않도록 필터링